### PR TITLE
added rateFFGain to tune.py

### DIFF
--- a/selfdrive/controls/lib/latcontrol_pid.py
+++ b/selfdrive/controls/lib/latcontrol_pid.py
@@ -92,6 +92,7 @@ class LatControlPID(object):
         self.react_mpc = (float(self.kegman.conf['reactMPC']))
         self.damp_mpc = (float(self.kegman.conf['dampMPC']))
         self.deadzone = float(self.kegman.conf['deadzone'])
+        self.rate_ff_gain = float(self.kegman.conf['rateFFGain'])
         self.wiggle_angle = float(self.kegman.conf['wiggleAngle'])
         self.accel_limit = (float(self.kegman.conf['accelLimit']))
         self.polyReact = min(11, max(0, int(10 * float(self.kegman.conf['polyReact']))))

--- a/tune.py
+++ b/tune.py
@@ -43,7 +43,7 @@ button_delay = 0.2
 kegman = kegman_conf()
 #kegman.conf['tuneGernby'] = "1"
 #kegman.write_config(kegman.conf)
-param = ["Kp", "Ki", "reactMPC","dampMPC", "reactSteer", "dampSteer", "reactCenter0", "reactCenter1", "reactCenter2", "polyFactor", "polyReact", "polyDamp", "advanceSteer", "angleFactor", "discreteAngle", "accelLimit","wiggleAngle", "deadzone", "modelFactor", "firstModel", "lastModel"]
+param = ["Kp", "Ki", "rateFFGain", "reactMPC","dampMPC", "reactSteer", "dampSteer", "reactCenter0", "reactCenter1", "reactCenter2", "polyFactor", "polyReact", "polyDamp", "advanceSteer", "angleFactor", "discreteAngle", "accelLimit","wiggleAngle", "deadzone", "modelFactor", "firstModel", "lastModel"]
 
 j = 0
 while True:


### PR DESCRIPTION
Choose one of the templates below:

# Fingerprint
This pull requests adds a fingerprint for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...

# Car support
This pull requests adds support for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...
This is an explorer link to a drive with openpilot system enabled: ...

# Feature
This pull requests adds feature X

## Description
Explain what the feature does

## Testing
Explain how the feature was tested. Either by the added unit tests, or what tests were performed while driving.
